### PR TITLE
orderItems werden als JSON auf localhost..../api/orders.php angezeigt

### DIFF
--- a/api/orders.php
+++ b/api/orders.php
@@ -33,5 +33,13 @@ foreach ($data->order_data as $entry) { // $entry sind die einzelnen Objekte ...
     $result = $stmt2->execute();
 }
 
+$allOrders = [];
+$stmtGet = $db->prepare('SELECT * FROM orderItems');
+$list = $stmtGet->execute();
+while($row = $list->fetchArray(SQLITE3_ASSOC)) {
+    array_push($allOrders, $row);
+}
+
+echo json_encode($allOrders);
 // Prepared-Statements schützen vor SQL-Injection, indem sie verhindern, dass Eintragungen als SQL-Code gelesen werden können. Sie werden als reine Daten eingetragen.
 


### PR DESCRIPTION
... allerdings habe ich erst fälschlicherweise die Tabelle orders anzeigen lassen und dabei gemerkt, dass mit jedem Refresh im Browser ein neuer Eintrag in der Tabelle orders hinzukommt. Auch wenn der Endpunkt die orderItems anzeigt. Es wird gleichzeitig mit dem GET-Request gleichzeitig der POST-Request mitgesendet, der, ohne mit einem JSON gefüttert zu werden, nur bei orders einen neuen Eintrag anlegt. Hierfür öffne ich ein neues Issue.

Closes #27